### PR TITLE
Fix __remove.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@
   // Removes an item from an array
   function __remove(array, item) {
     var index = _.indexOf(array, item);
-    if (index != 1) array.splice(index, 1);
+    if (index != -1) array.splice(index, 1);
   }
 
   function get(collection, id) {


### PR DESCRIPTION
Bug: Won't remove 1st element if exists.
Fix: Will remove any element if exists. (_.indexOf returns -1 if not found, not 1).

Apologies for the trailing newline at the end of the file, the GitHub web-based editor added that for me.
